### PR TITLE
use react helpers to traverse children

### DIFF
--- a/build/index.js
+++ b/build/index.js
@@ -80,12 +80,10 @@
                 if (route.props.name) {
                     _this.routesMap[route.props.name] = newPrefix;
                 }
-            }
 
-            var children = route.props.children || {};
-
-            for (var k in children) {
-                _this.mergeRouteTree(children[k], newPrefix);
+                React.Children.forEach(route.props.children, function (child) {
+                    _this.mergeRouteTree(child, newPrefix);
+                });
             }
         });
     };

--- a/lib/index.js
+++ b/lib/index.js
@@ -59,11 +59,10 @@ NamedURLResolverClass.prototype.mergeRouteTree = function(routes, prefix="") {
             if (route.props.name) {
                 this.routesMap[route.props.name] = newPrefix;
             }
-        }
 
-        var children = route.props.children || {};
-        for(var k in children) {
-            this.mergeRouteTree(children[k], newPrefix);
+            React.Children.forEach(route.props.children, (child) => {
+                this.mergeRouteTree(child, newPrefix);
+            });
         }
     });
 };


### PR DESCRIPTION
Hi! Thank you for this package, it's exactly what I was looking for.

Unfortunately, "from the box" it didn't work for me, failing [here](https://github.com/adamziel/react-router-named-routes/blob/master/build/index.js#L85) with `Can't read property "children" of undefined`. 

I don't know exactly why it happens - seems that some bundler-specific data was added to `children` and loop iterated over it - but anyway: it is stated in React guides that `children` is an opaque structure and we should interact with it **only** using React's specific helpers.

Also there is a logical error: first you [check whether `props` exist](https://github.com/adamziel/react-router-named-routes/blob/master/build/index.js#L74), and then read `children` from it without any check.

With this patch your package works for me just perfect.
