### PR TITLE
Absolute paths for nested routes

### DIFF
--- a/build/index.js
+++ b/build/index.js
@@ -73,9 +73,9 @@
 
             if (route.props) {
                 var routePath = route.props.path || "";
-                var newPrefix = [prefix, routePath].filter(function (x) {
+                var newPrefix = (routePath != null && routePath[0] === "/" ? routePath : [prefix, routePath].filter(function (x) {
                     return x;
-                }).join("/").replace(/\/+/g, "/");
+                }).join("/")).replace(/\/+/g, "/");
 
                 if (route.props.name) {
                     _this.routesMap[route.props.name] = newPrefix;

--- a/lib/index.js
+++ b/lib/index.js
@@ -92,8 +92,8 @@ var Link = React.createClass({
 });
 
 
-function MonkeyPatchNamedRoutesSupport(routes) {
-    NamedURLResolver.mergeRouteTree(routes, "/");
+function MonkeyPatchNamedRoutesSupport(routes, basename="/") {
+    NamedURLResolver.mergeRouteTree(routes, basename);
     ReactRouter.Link = Link;
 };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -55,7 +55,10 @@ NamedURLResolverClass.prototype.mergeRouteTree = function(routes, prefix="") {
         var newPrefix = "";
         if(route.props) {
             var routePath = (route.props.path || "");
-            var newPrefix = [prefix, routePath].filter(x=>x).join("/").replace(/\/+/g, "/");
+            var newPrefix = ((routePath != null && routePath[0] === "/")
+                ? routePath 
+                : [prefix, routePath].filter(x=>x).join("/")
+            ).replace(/\/+/g, "/");
             if (route.props.name) {
                 this.routesMap[route.props.name] = newPrefix;
             }

--- a/test/named-routes-test.js
+++ b/test/named-routes-test.js
@@ -29,9 +29,9 @@ var createComplexRouteTree = function() {
 
             React.createElement(Route, {name: 'users', path: '/users'}, [
                 React.createElement(IndexRoute, {name: 'users.index'}),
-                React.createElement(Route, {name: 'users.list', path: '/list'}),
-                React.createElement(Route, {name: 'users.show', path: '/:id'}),
-                React.createElement(Route, {path: '/:id/edit'})
+                React.createElement(Route, {name: 'users.list', path: 'list'}),
+                React.createElement(Route, {name: 'users.show', path: ':id'}),
+                React.createElement(Route, {path: ':id/edit'})
             ])
         ])
     );
@@ -104,6 +104,23 @@ describe('NamedURLResolver', function() {
             'users.list': '/users/list',
             'users.show': '/users/:id'
         });
+    });
+
+    it('correctly maps absolute paths for nested routes', function() {
+        resolver = new NamedURLResolverClass();
+        resolver.mergeRouteTree(
+            React.createElement(Route, { path: "/users" }, [
+                React.createElement(Route, {name: 'users.show', path: '/:id'}),
+                React.createElement(Route, {name: 'users.list', path: '/list'})
+            ])
+        );
+
+        expect(resolver.routesMap).to.deep.equal({
+            'users.show': '/:id',
+            'users.list': '/list'
+        });
+
+        expect(resolver.resolve("users.list")).to.equal("/list");
     });
 
     it('correctly escapes route parameters', function() {


### PR DESCRIPTION
Added proper support of this feature: https://github.com/rackt/react-router/blob/master/docs%2Fguides%2Fbasics%2FRouteConfiguration.md#decoupling-the-ui-from-the-url.

Also added `basename` param for top-level `MonkeyPatchNamedRoutesSupport` function - taking into account, that router's history can be created like this: https://github.com/rackt/history/blob/master/docs%2FBasenameSupport.md
