### PR TITLE
Resolve optional and splat

### DIFF
--- a/build/index.js
+++ b/build/index.js
@@ -36,7 +36,7 @@
     var reResolvedOptionalParams = /\(([^:*?#]+?)\)/g;
     var reUnresolvedOptionalParams = /\([^:?#]*:[^?#]*?\)/g;
     var reTokens = /<(.*?)>/g;
-    var reSlashTokens = /!@slash@!/g;
+    var reSlashTokens = /_!slash!_/g;
 
     NamedURLResolverClass.prototype.resolve = function (name, params) {
         if (name && name in this.routesMap) {
@@ -62,7 +62,7 @@
                                 return "";
                             } else {
                                 var tokenName = 'splat' + i;
-                                tokens[tokenName] = match === "*" ? encodeURIComponent(val) : encodeURIComponent(val.toString().replace(/\//g, "!@slash@!")).replace(reSlashTokens, "/");
+                                tokens[tokenName] = match === "*" ? encodeURIComponent(val) : encodeURIComponent(val.toString().replace(/\//g, "_!slash!_")).replace(reSlashTokens, "/");
                                 return '<' + tokenName + '>';
                             }
                         });

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,10 +8,6 @@ var OriginalLink = ReactRouter.Link;
 //                                      runtime
 function NamedURLResolverClass() {
     this.routesMap = {};
-    this.escapeSequences = [
-        [/:/g,  '_'],
-        [/\//g, '_']
-    ];
 }
 
 function toArray(val) {
@@ -24,22 +20,8 @@ var reRepeatingSlashes = /\/+/g; // "/some//path"
 var reSplatParams = /\*{1,2}/g;  // "/some/*/complex/**/path"
 var reResolvedOptionalParams = /\(([^:*?#]+?)\)/g; // "/path/with/(resolved/params)"
 var reUnresolvedOptionalParams = /\([^:?#]*:[^?#]*?\)/g; // "/path/with/(groups/containing/:unresolved/optional/:params)"
-
-
-NamedURLResolverClass.prototype.escape = function(string, escapeSlashes = true) {
-    if(string === undefined) {
-        return "";
-    }
-
-    this.escapeSequences.forEach(function(fromto, idx) {
-        // need ability to omit escaping slashes, when reversing splat params
-        if (!(idx === 1 && !escapeSlashes)) {
-            string = string.replace(fromto[0], fromto[1]);    
-        }
-    });
-
-    return string;
-};
+var reTokens = /<(.*?)>/g;
+var reSlashTokens = /!@slash@!/g;
 
 NamedURLResolverClass.prototype.resolve = function(name, params) {
     if(name && (name in this.routesMap)) {
@@ -48,6 +30,8 @@ NamedURLResolverClass.prototype.resolve = function(name, params) {
         if(!params) {
             return routePath;
         }
+
+        var tokens = {};
 
         for (var paramName in params) {
             if (params.hasOwnProperty(paramName)) {
@@ -58,8 +42,17 @@ NamedURLResolverClass.prototype.resolve = function(name, params) {
                     var i = 0;
                     routePath = routePath.replace(reSplatParams, (match) => {
                         var val = paramValue[i++];
-                        // don't escape slashes for double star, as "**" considered greedy by RR spec
-                        return val == null ? "" : this.escape('' + val, match === "*");
+                        if (val == null) {
+                            return "";
+                        } else {
+                            var tokenName = `splat${i}`;
+                            tokens[tokenName] = match === "*" 
+                                ? encodeURIComponent(val)
+                                // don't escape slashes for double star, as "**" considered greedy by RR spec
+                                : encodeURIComponent(val.toString().replace(/\//g, "!@slash@!")).replace(reSlashTokens, "/");
+                            return `<${tokenName}>`;
+                        }
+                        //return val == null ? "" : this.escape('' + val, match === "*");
                     });
                 } else {
                     // Rougly resolve all named placeholders.
@@ -71,8 +64,10 @@ NamedURLResolverClass.prototype.resolve = function(name, params) {
                     // - "/path/:param(/:another_param)"
                     // - "/path(/:param/:another_param)"
                     var paramRegex = new RegExp('(\/|\\(|\\)|^):' + paramName + '(\/|\\)|\\(|$)');
-                    var replacement = '$1' + this.escape('' + paramValue) + '$2';
-                    routePath = routePath.replace(paramRegex, replacement);
+                    routePath = routePath.replace(paramRegex, (match, g1, g2) => {
+                        tokens[paramName] = encodeURIComponent(paramValue);
+                        return `${g1}<${paramName}>${g2}`;
+                    });
                 }
             }
         }
@@ -81,6 +76,8 @@ NamedURLResolverClass.prototype.resolve = function(name, params) {
             .replace(reResolvedOptionalParams, "$1")
             // Remove all sequences containing at least one unresolved optional param
             .replace(reUnresolvedOptionalParams, "")
+            // After everything related to RR syntax is removed, insert actual values
+            .replace(reTokens, (match, token) => tokens[token])
             // Finally remove repeating slashes
             .replace(reRepeatingSlashes, "/");
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,13 +14,28 @@ function NamedURLResolverClass() {
     ];
 }
 
-NamedURLResolverClass.prototype.escape = function(string) {
+function toArray(val) {
+    return Object.prototype.toString.call(val) !== '[object Array]' ? [ val ] : val;
+}
+
+// Cached regexps:
+
+var reRepeatingSlashes = /\/+/g; // "/some//path"
+var reSplatParams = /\*{1,2}/g;  // "/some/*/complex/**/path"
+var reResolvedOptionalParams = /\(([^:*?#]+?)\)/g; // "/path/with/(resolved/params)"
+var reUnresolvedOptionalParams = /\([^:?#]*:[^?#]*?\)/g; // "/path/with/(groups/containing/:unresolved/optional/:params)"
+
+
+NamedURLResolverClass.prototype.escape = function(string, escapeSlashes = true) {
     if(string === undefined) {
         return "";
     }
 
-    this.escapeSequences.forEach(function(fromto) {
-        string = string.replace(fromto[0], fromto[1]);
+    this.escapeSequences.forEach(function(fromto, idx) {
+        // need ability to omit escaping slashes, when reversing splat params
+        if (!(idx === 1 && !escapeSlashes)) {
+            string = string.replace(fromto[0], fromto[1]);    
+        }
     });
 
     return string;
@@ -28,26 +43,53 @@ NamedURLResolverClass.prototype.escape = function(string) {
 
 NamedURLResolverClass.prototype.resolve = function(name, params) {
     if(name && (name in this.routesMap)) {
-        if(!params) params = {};
-
         var routePath = this.routesMap[name];
-        for(var paramName in params) {
-            if(params.hasOwnProperty(paramName)) {
-                let paramRegex = new RegExp('(/|^):' + paramName + '(/|$)');
-                let paramValue = this.escape('' + params[paramName]);
-                routePath = routePath.replace(paramRegex, '$1' + paramValue + '$2');
+
+        if(!params) {
+            return routePath;
+        }
+
+        for (var paramName in params) {
+            if (params.hasOwnProperty(paramName)) {
+                var paramValue = params[paramName];
+        
+                if (paramName === "splat") { // special param name in RR, used for "*" and "**" placeholders
+                    paramValue = toArray(paramValue); // when there are multiple globs, RR defines "splat" param as array.
+                    var i = 0;
+                    routePath = routePath.replace(reSplatParams, (match) => {
+                        var val = paramValue[i++];
+                        // don't escape slashes for double star, as "**" considered greedy by RR spec
+                        return val == null ? "" : this.escape('' + val, match === "*");
+                    });
+                } else {
+                    // Rougly resolve all named placeholders.
+                    // Cases: 
+                    // - "/path/:param"
+                    // - "/path/(:param)"
+                    // - "/path(/:param)"
+                    // - "/path(/:param/):another_param"
+                    // - "/path/:param(/:another_param)"
+                    // - "/path(/:param/:another_param)"
+                    var paramRegex = new RegExp('(\/|\\(|\\)|^):' + paramName + '(\/|\\)|\\(|$)');
+                    var replacement = '$1' + this.escape('' + paramValue) + '$2';
+                    routePath = routePath.replace(paramRegex, replacement);
+                }
             }
         }
-        return routePath;
+        return routePath
+            // Remove braces around resolved optional params (i.e. "/path/(value)")
+            .replace(reResolvedOptionalParams, "$1")
+            // Remove all sequences containing at least one unresolved optional param
+            .replace(reUnresolvedOptionalParams, "")
+            // Finally remove repeating slashes
+            .replace(reRepeatingSlashes, "/");
     }
 
     return name;
 };
 
 NamedURLResolverClass.prototype.mergeRouteTree = function(routes, prefix="") {
-    if(Object.prototype.toString.call(routes) !== '[object Array]') {
-        routes = [routes];
-    }
+    routes = toArray(routes);
 
     routes.forEach((route) => {
         if(!route) return;
@@ -55,7 +97,7 @@ NamedURLResolverClass.prototype.mergeRouteTree = function(routes, prefix="") {
         var newPrefix = "";
         if(route.props) {
             var routePath = (route.props.path || "");
-            var newPrefix = [prefix, routePath].filter(x=>x).join("/").replace(/\/+/g, "/");
+            var newPrefix = [prefix, routePath].filter(x=>x).join("/").replace(reRepeatingSlashes, "/");
             if (route.props.name) {
                 this.routesMap[route.props.name] = newPrefix;
             }

--- a/lib/index.js
+++ b/lib/index.js
@@ -21,7 +21,7 @@ var reSplatParams = /\*{1,2}/g;  // "/some/*/complex/**/path"
 var reResolvedOptionalParams = /\(([^:*?#]+?)\)/g; // "/path/with/(resolved/params)"
 var reUnresolvedOptionalParams = /\([^:?#]*:[^?#]*?\)/g; // "/path/with/(groups/containing/:unresolved/optional/:params)"
 var reTokens = /<(.*?)>/g;
-var reSlashTokens = /!@slash@!/g;
+var reSlashTokens = /_!slash!_/g;
 
 NamedURLResolverClass.prototype.resolve = function(name, params) {
     if(name && (name in this.routesMap)) {
@@ -49,10 +49,9 @@ NamedURLResolverClass.prototype.resolve = function(name, params) {
                             tokens[tokenName] = match === "*" 
                                 ? encodeURIComponent(val)
                                 // don't escape slashes for double star, as "**" considered greedy by RR spec
-                                : encodeURIComponent(val.toString().replace(/\//g, "!@slash@!")).replace(reSlashTokens, "/");
+                                : encodeURIComponent(val.toString().replace(/\//g, "_!slash!_")).replace(reSlashTokens, "/");
                             return `<${tokenName}>`;
                         }
-                        //return val == null ? "" : this.escape('' + val, match === "*");
                     });
                 } else {
                     // Rougly resolve all named placeholders.

--- a/test/named-routes-test.js
+++ b/test/named-routes-test.js
@@ -273,7 +273,7 @@ describe('Link', function() {
         expect(root.children[i++].getAttribute('href')).to.equal('/users/list');
         expect(root.children[i++].getAttribute('href')).to.equal('/users/:id');
         expect(root.children[i++].getAttribute('href')).to.equal('/users/4');
-        expect(root.children[i++].getAttribute('href')).to.equal('/users/_mal_ici__ous');
+        expect(root.children[i++].getAttribute('href')).to.equal('/users/' + encodeURIComponent(':mal/ici/:ous'));
 
         expect(root.children[i++].getAttribute('href')).to.equal('/some-unnamed-path');
         expect(root.children[i++].getAttribute('href')).to.equal('/');

--- a/test/named-routes-test.js
+++ b/test/named-routes-test.js
@@ -123,12 +123,6 @@ describe('NamedURLResolver', function() {
         expect(resolver.resolve("users.list")).to.equal("/list");
     });
 
-    it('correctly escapes route parameters', function() {
-        expect(resolver.escape(':abc')).to.equal('_abc');
-        expect(resolver.escape(':abc/:zxd')).to.equal('_abc__zxd');
-        expect(resolver.escape(undefined)).to.equal("");
-    });
-
     it('correctly resolve named routes', function() {
         resolver.mergeRouteTree(createComplexRouteTree());
         expect(resolver.resolve("root")).to.equal("/");
@@ -152,9 +146,9 @@ describe('NamedURLResolver', function() {
         expect(resolver.resolve("test1", {id: 4, 'id-parent': 5})).to.equal("/users/5/4");
         expect(resolver.resolve("test2", {colon: 7})).to.equal("/users/semi:colon/7");
 
-        expect(resolver.resolve("users.show", {id: 'id/:id'})).to.equal("/users/id__id");
-        expect(resolver.resolve("test1", {id: 'id/:id', 'id-parent': 'idp:id'})).to.equal("/users/idp_id/id__id");
-        expect(resolver.resolve("test2", {colon: 'colon:colon'})).to.equal("/users/semi:colon/colon_colon");
+        expect(resolver.resolve("users.show", {id: 'id/:id'})).to.equal("/users/" + encodeURIComponent("id/:id"));
+        expect(resolver.resolve("test1", {id: 'id/:id', 'id-parent': 'idp:id'})).to.equal("/users/" + encodeURIComponent("idp:id") + "/" + encodeURIComponent("id/:id"));
+        expect(resolver.resolve("test2", {colon: 'colon:colon'})).to.equal("/users/semi:colon/" + encodeURIComponent("colon:colon"));
     });
 
     it('correctly resolves optional params', function () {
@@ -183,6 +177,8 @@ describe('NamedURLResolver', function() {
 
         expect(resolver.resolve("test7", {param1: 1})).to.equal("/path/1/", "Trailing omit case 1");
         expect(resolver.resolve("test8", {param1: 1})).to.equal("/path/1", "Trailing omit case 2");
+        
+        expect(resolver.resolve("test8", {param1: "p(1)", param2: "p(2)"})).to.equal("/path/p(1)/p(2)", "Params with parentheses");
 
         // if any part of optional sequence is omitted, entire sequence is omitted
         expect(resolver.resolve("test9", {param1: 1})).to.equal("/path", "Omitted sequence");
@@ -202,14 +198,14 @@ describe('NamedURLResolver', function() {
 
         expect(resolver.resolve("test1", {splat: 1})).to.equal("/some/1", "Trailing single star");
         expect(resolver.resolve("test2", {splat: 1})).to.equal("/some/1/path", "Middle single star");
-        expect(resolver.resolve("test1", {splat: "slash/here"})).to.equal("/some/slash_here", "Slash with single star");
+        expect(resolver.resolve("test1", {splat: "slash/here"})).to.equal("/some/" + encodeURIComponent("slash/here"), "Slash with single star");
 
         expect(resolver.resolve("test3", {splat: 1})).to.equal("/some/1", "Trailing double star");
         expect(resolver.resolve("test4", {splat: 1})).to.equal("/some/1/path", "Middle double star");
         expect(resolver.resolve("test3", {splat: "slash/here"})).to.equal("/some/slash/here", "Slash with double star");
         
-        expect(resolver.resolve("test5", {splat: "first/splat"})).to.equal("/some/first_splat/path/", "Multiple globs 1");
-        expect(resolver.resolve("test5", {splat: ["first/splat", "second/splat"]})).to.equal("/some/first_splat/path/second/splat", "Multiple globs 2");
+        expect(resolver.resolve("test5", {splat: "first/splat"})).to.equal("/some/" + encodeURIComponent("first/splat") + "/path/", "Multiple globs 1");
+        expect(resolver.resolve("test5", {splat: ["first/splat", "second/splat"]})).to.equal("/some/" + encodeURIComponent("first/splat") + "/path/second/splat", "Multiple globs 2");
 
     });
 });


### PR DESCRIPTION
Here is support for resolving optional and splat params, accordingly to https://github.com/rackt/react-router/blob/master/docs%2Fguides%2Fbasics%2FRouteMatching.md#path-syntax.

It seems to be the last thing needed for fully enjoying named routes with RR 1.0 =)

Please review it, as solution is rough enough, I think (especially what is related to escaping slashes in param values).
