### PR TITLE
Fixed react 15 warning about params attribute set to anchor element

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -120,11 +120,11 @@ var NamedURLResolver = new NamedURLResolverClass();
 var Link = React.createClass({
 
     render() {
-        var {to, resolver, ...rest} = this.props;
+        var {to, resolver, params, ...rest} = this.props;
         if(!resolver) resolver = NamedURLResolver;
         to = resolver.resolve(
             to,
-            this.props.params
+            params
         );
 
         return <OriginalLink to={to} {...rest} />;


### PR DESCRIPTION
React 15 complains if you try to add attributes to standard element that is not standard attributes. This prevents `params` to be added to the `<a>` tag.
