### PR TITLE
Fix React.createClass deprecation warning in React 15.5

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,7 @@
 var React = require('react');
 var ReactRouter = require('react-router');
 var OriginalLink = ReactRouter.Link;
+var createReactClass = require('create-react-class');
 
 // Deliberately not using ES6 classes - babel spits out too much boilerplate
 //                                      and I don't want to add a dependency on babel
@@ -117,7 +118,7 @@ NamedURLResolverClass.prototype.reset = function() {
 
 var NamedURLResolver = new NamedURLResolverClass();
 
-var Link = React.createClass({
+var Link = createReactClass({
 
     render() {
         var {to, resolver, params, ...rest} = this.props;

--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
   "bugs": {
     "url": "https://github.com/adamziel/react-router-named-routes/issues"
   },
-  "dependencies": {
-  },
+  "dependencies": {},
   "description": "Adds support for named routes to React-Router 1, 2, and 3",
   "devDependencies": {
     "babel": "^6.0.15",
@@ -23,6 +22,7 @@
     "babel-preset-stage-3": "^6.0.15",
     "babel-runtime": "^6.0.14",
     "chai": "^3.4.0",
+    "create-react-class": "^15.6.0",
     "history": "^3.*",
     "jsdom": "^7.0.2",
     "mocha": "^2.3.3",


### PR DESCRIPTION
This fixes the following deprecation warning:

> Warning: Accessing createClass via the main React package is deprecated, and will be removed in React v16.0. Use a plain JavaScript class instead. If you're not yet ready to migrate, create-react-class v15.* is available on npm as a temporary, drop-in replacement. For more info see https://fb.me/react-create-class