### PR TITLE
Fixed to support RR4 optional params pattern correctly

### DIFF
--- a/build/index.js
+++ b/build/index.js
@@ -200,7 +200,7 @@
                             tokens[paramName] = encodeURIComponent(paramValue);
                             return g1 + '<' + paramName + '>' + g2;
                         });
-                        var paramRegexRR4 = new RegExp('(.*)' + paramName + '\\?(.*)');
+                        var paramRegexRR4 = new RegExp('(.*):' + paramName + '\\?(.*)');
                         routePath = routePath.replace(paramRegexRR4, function (match, g1, g2) {
                             tokens[paramName] = encodeURIComponent(paramValue);
                             return g1 + '<' + paramName + '>' + g2;

--- a/lib/index.js
+++ b/lib/index.js
@@ -156,7 +156,7 @@ function formatRoute(routePath, params) {
                         tokens[paramName] = encodeURIComponent(paramValue);
                         return `${g1}<${paramName}>${g2}`;
                     });
-                    var paramRegexRR4 = new RegExp('(.*)' + paramName + '\\?(.*)');
+                    var paramRegexRR4 = new RegExp('(.*):' + paramName + '\\?(.*)');
                     routePath = routePath.replace(paramRegexRR4, (match, g1, g2) => {
                          tokens[paramName] = encodeURIComponent(paramValue);
                          return `${g1}<${paramName}>${g2}`;

--- a/test/named-routes-test.js
+++ b/test/named-routes-test.js
@@ -424,10 +424,10 @@ describe('formatRoute', function() {
     });
 
     it('correctly resolves React Router 4 optional params', function() {
-        expect(formatRoute("/path/param?", {param: 1})).to.equal("/path/1", "Substitute case");
-        expect(formatRoute("/path/param?")).to.equal("/path", "Simple omit case");
-        expect(formatRoute("/path/param1?/param2?", {param2: 2})).to.equal("/path/2", "Middle omit case 1");
-        expect(formatRoute("/path/:param1/param2?", {param1: 1})).to.equal("/path/1", "Trailing omit case 1");
+        expect(formatRoute("/path/:param?", {param: 1})).to.equal("/path/1", "Substitute case");
+        expect(formatRoute("/path/:param?")).to.equal("/path", "Simple omit case");
+        expect(formatRoute("/path/:param1?/:param2?", {param2: 2})).to.equal("/path/2", "Middle omit case 1");
+        expect(formatRoute("/path/:param1/:param2?", {param1: 1})).to.equal("/path/1", "Trailing omit case 1");
     });
 
     it('correctly resolves splat params', function () {


### PR DESCRIPTION
In the previous PR (#18) the pattern is not the correct one for React Router 4.

This PR fixes it.

Related docs: https://github.com/pillarjs/path-to-regexp#optional (in the library used by RR4)